### PR TITLE
RO compatibility

### DIFF
--- a/GameData/ThunderAerospace/TacLifeSupportMFT/MM_AddResources.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportMFT/MM_AddResources.cfg
@@ -1,5 +1,5 @@
 
-@PART[*]:HAS[#CrewCapacity[1],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[*]:HAS[#CrewCapacity[1],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -10,7 +10,7 @@
 	}
 }
 
-@PART[*]:HAS[#CrewCapacity[2],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[*]:HAS[#CrewCapacity[2],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -21,7 +21,7 @@
 	}
 }
 
-@PART[*]:HAS[#CrewCapacity[3],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[*]:HAS[#CrewCapacity[3],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -32,7 +32,7 @@
 	}
 }
 
-@PART[*]:HAS[#CrewCapacity[4],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[*]:HAS[#CrewCapacity[4],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -43,7 +43,7 @@
 	}
 }
 
-@PART[*]:HAS[#CrewCapacity[5],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[*]:HAS[#CrewCapacity[5],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels&!RealismOverhaul]
 {
 	MODULE
 	{
@@ -54,7 +54,7 @@
 	}
 }
 
-@PART[*]:HAS[#CrewCapacity[6],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[*]:HAS[#CrewCapacity[6],@MODULE[ModuleCommand],!MODULE[ModuleFuelTanks]]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels&!RealismOverhaul]
 {
 	MODULE
 	{


### PR DESCRIPTION
Ensure that TACLS does NOT add MFT to pods when RO is present.
