### PR TITLE
Updated stack containers/recylers for attachment size nodes

### DIFF
--- a/GameData/ThunderAerospace/TacLifeSupportContainers/FoodLarge.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportContainers/FoodLarge.cfg
@@ -19,8 +19,8 @@ PART
 	rescaleFactor = 2
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 2
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportContainers/FoodSmall.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportContainers/FoodSmall.cfg
@@ -19,8 +19,8 @@ PART
 	rescaleFactor = 0.5
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 0
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportContainers/LifeSupportLarge.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportContainers/LifeSupportLarge.cfg
@@ -19,8 +19,8 @@ PART
 	rescaleFactor = 2
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 2
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportContainers/LifeSupportSmall.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportContainers/LifeSupportSmall.cfg
@@ -19,8 +19,8 @@ PART
 	rescaleFactor = 0.5
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 0
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportContainers/OxygenLarge.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportContainers/OxygenLarge.cfg
@@ -19,8 +19,8 @@ PART
 	rescaleFactor = 2
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 2
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportContainers/OxygenSmall.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportContainers/OxygenSmall.cfg
@@ -19,8 +19,8 @@ PART
 	rescaleFactor = 0.5
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 0
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportContainers/WasteLarge.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportContainers/WasteLarge.cfg
@@ -19,8 +19,8 @@ PART
 	rescaleFactor = 2
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 2
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportContainers/WasteSmall.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportContainers/WasteSmall.cfg
@@ -19,8 +19,8 @@ PART
 	rescaleFactor = 0.5
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 0
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportContainers/WaterLarge.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportContainers/WaterLarge.cfg
@@ -19,8 +19,8 @@ PART
 	rescaleFactor = 2
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 2
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportContainers/WaterSmall.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportContainers/WaterSmall.cfg
@@ -19,8 +19,8 @@ PART
 	rescaleFactor = 0.5
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 0
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportRecyclers/Recycler_CarbonExtractorLarge.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportRecyclers/Recycler_CarbonExtractorLarge.cfg
@@ -46,8 +46,8 @@ PART
 	rescaleFactor = 2
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 2
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportRecyclers/Recycler_SabatierCarbonRecyclerLarge.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportRecyclers/Recycler_SabatierCarbonRecyclerLarge.cfg
@@ -46,8 +46,8 @@ PART
 	rescaleFactor = 2
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 2
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0

--- a/GameData/ThunderAerospace/TacLifeSupportRecyclers/Recycler_WaterPurifierLarge.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportRecyclers/Recycler_WaterPurifierLarge.cfg
@@ -46,8 +46,8 @@ PART
 	rescaleFactor = 2
 
 	// --- node Definitions ---
-	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 2
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0


### PR DESCRIPTION
Minor update to 0.625m stack container parts for stack_node size 0 and 2.5m parts for stack_note size 2

Should help with joint strength for 2.5m-to-2.5m connections (correct nodes for part size) and also FAR (corrects node mismatches for connections between parts which are the same size)