### PR TITLE
Add Life Support Monitoring Window and warning messages to Tracking Station

### DIFF
--- a/Source/LifeSupportController.cs
+++ b/Source/LifeSupportController.cs
@@ -107,7 +107,6 @@ namespace Tac
             {
                 return;
             }
-            print ("TAC FixedUpdate!");
             double currentTime = Planetarium.GetUniversalTime();
             var allVessels = new List<Vessel>();
             if (FlightGlobals.ready) {
@@ -116,7 +115,6 @@ namespace Tac
             var knownVessels = gameSettings.knownVessels;
 
             var vesselsToDelete = new List<Guid>();
-            print ("TAC FixedUpdate: foreach");
             foreach (var entry in knownVessels)
             {
                 Guid vesselId = entry.Key;
@@ -157,7 +155,7 @@ namespace Tac
                         ConsumeResources(currentTime, vessel, vesselInfo);
                     }
                 }
-                    
+
                 if (vesselInfo.numCrew > 0)
                 {
                     double foodRate = globalSettings.FoodConsumptionRate * vesselInfo.numCrew;

--- a/Source/LifeSupportMonitoringWindow.cs
+++ b/Source/LifeSupportMonitoringWindow.cs
@@ -99,14 +99,13 @@ namespace Tac
 
         protected override void DrawWindowContents(int windowId)
         {
-            if (FlightGlobals.ready)
-            {
-                scrollPosition = GUILayout.BeginScrollView(scrollPosition, scrollStyle);
-                GUILayout.BeginVertical();
-                GUILayout.Space(4);
+            scrollPosition = GUILayout.BeginScrollView(scrollPosition, scrollStyle);
+            GUILayout.BeginVertical();
+            GUILayout.Space(4);
 
-                double currentTime = Planetarium.GetUniversalTime();
+            double currentTime = Planetarium.GetUniversalTime();
 
+            if (FlightGlobals.ready) {
                 // Draw the active vessel first
                 Vessel activeVessel = FlightGlobals.ActiveVessel;
                 if (activeVessel != null)
@@ -140,10 +139,18 @@ namespace Tac
                         GUILayout.Space(10);
                     }
                 }
-
-                GUILayout.EndVertical();
-                GUILayout.EndScrollView();
             }
+            else
+            {
+                foreach (var entry in gameSettings.knownVessels)
+                {
+                    DrawVesselInfo (entry.Value, currentTime);
+                    GUILayout.Space(10);
+                }
+            }
+
+            GUILayout.EndVertical();
+            GUILayout.EndScrollView();
 
             GUILayout.Space(8);
 

--- a/Source/TacLifeSupport.cs
+++ b/Source/TacLifeSupport.cs
@@ -68,9 +68,17 @@ namespace Tac
                 this.Log("Adding SpaceCenterManager");
                 var c = gameObject.AddComponent<SpaceCenterManager>();
                 children.Add(c);
+                /* This does show the window, but only shows one button in the toolbar
                 this.Log("Adding LifeSupportController");
-                var see = gameObject.AddComponent<LifeSupportController>();
-                children.Add(see);
+                var d = gameObject.AddComponent<LifeSupportController>();
+                children.Add(d);
+                */
+            }
+            else if (HighLogic.LoadedScene == GameScenes.TRACKSTATION)
+            {
+                this.Log("Adding LifeSupportController");
+                var c = gameObject.AddComponent<LifeSupportController>();
+                children.Add(c);
             }
             else if (HighLogic.LoadedScene == GameScenes.FLIGHT)
             {

--- a/Source/TacLifeSupport.cs
+++ b/Source/TacLifeSupport.cs
@@ -68,6 +68,9 @@ namespace Tac
                 this.Log("Adding SpaceCenterManager");
                 var c = gameObject.AddComponent<SpaceCenterManager>();
                 children.Add(c);
+                this.Log("Adding LifeSupportController");
+                var see = gameObject.AddComponent<LifeSupportController>();
+                children.Add(see);
             }
             else if (HighLogic.LoadedScene == GameScenes.FLIGHT)
             {


### PR DESCRIPTION
This basically just avoids calling FlightGlobals when it's not ready.

Commented out is code to add the monitoring window to the Space Center too, but it doesn't work right.  Only one button shows up in the toolbar at the Space Center.  I suspect this is an issue with TacLib's ButtonWrapper not supporting multiple buttons, but I haven't tracked it down yet.

![screen shot 2015-06-20 at 4 58 32 pm](https://cloud.githubusercontent.com/assets/5103358/8267522/ae60dd0c-176d-11e5-903b-0df13b5abc48.png)