### PR TITLE
Sort the monitoring window by who's going to run out of resources first

### DIFF
--- a/Source/LifeSupportMonitoringWindow.cs
+++ b/Source/LifeSupportMonitoringWindow.cs
@@ -131,7 +131,7 @@ namespace Tac
                     GUILayout.Space(10);
                 }
 
-                foreach (var entry in gameSettings.knownVessels)
+                foreach (var entry in sortedKnownVessels())
                 {
                     // The active vessel was already done above
                     if (entry.Key != activeVessel.id)
@@ -153,6 +153,11 @@ namespace Tac
             }
 
             GUI.Label(new Rect(4, windowPos.height - 13, windowPos.width - 20, 12), "TAC Life Support v" + version, versionStyle);
+        }
+
+        private IEnumerable<KeyValuePair<Guid, VesselInfo>> sortedKnownVessels()
+        {
+            return gameSettings.knownVessels.OrderBy (x => Math.Min (x.Value.estimatedTimeOxygenDepleted, Math.Min (x.Value.estimatedTimeFoodDepleted, x.Value.estimatedTimeWaterDepleted)));
         }
 
         private void DrawVesselInfo(VesselInfo vesselInfo, double currentTime)


### PR DESCRIPTION
Pretty simple change - just put the people who are about to die up top :)
The active vessel is still first.

![screen shot 2015-06-20 at 4 58 32 pm](https://cloud.githubusercontent.com/assets/5103358/8267561/c4229a98-176f-11e5-9c91-77ce36b0539d.png)
![screen shot 2015-06-20 at 5 06 22 pm](https://cloud.githubusercontent.com/assets/5103358/8267562/c425d2ee-176f-11e5-8b78-06b3da0b6406.png)
