### PR TITLE
HSP Values for TAC-LS Resources

### DIFF
--- a/GameData/ThunderAerospace/TacLifeSupport/TacResources.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupport/TacResources.cfg
@@ -6,7 +6,7 @@ RESOURCE_DEFINITION
    transfer = PUMP
    isTweakable = true
    unitCost = 0.238874700854701
-   // hsp = ?, default is 800
+   hsp = 1657 // specific heat capacity (kJ/tonne-K as units) @ 298 K
 }
 
 RESOURCE_DEFINITION
@@ -50,7 +50,7 @@ RESOURCE_DEFINITION
    transfer = PUMP
    isTweakable = true
    unitCost = 0
-   // hsp = ?, default is 800
+   hsp = 2710 // specific heat capacity (kJ/tonne-K as units) @ 293 K
 }
 
 RESOURCE_DEFINITION
@@ -61,5 +61,5 @@ RESOURCE_DEFINITION
    transfer = PUMP
    isTweakable = true
    unitCost = 0
-   hsp = 4000
+   hsp = 4183 // specific heat capacity (kJ/tonne-K as units)
 }


### PR DESCRIPTION
I noticed the question marks and thought to do a bit of back-of-the-envelope research.  I also give a rationale for a new number for wastewater.  Feel free to turn that one down if you disagree with my reasoning.

Assumptions (Food):

Food is freeze-dried for storage
Food has high protein content (mainly because that's what's in the paper, but there are good practical reasons:  it's cheap to send caviar to space because caviar has a lot of food value per ounce.  High protein content might also help combat atrophy--assuming that high protein isn't toxic)
Food is stored at ambient temperature (The astronauts need to be able to access the storage--especially if the inline tanks are passable)
Ambient temperature is 298 K (Comfy, climate-controlled space capsule)

Reference:
http://nopr.niscair.res.in/bitstream/123456789/7108/1/IJCT%2013(6)%20597-604.pdf (page 6)

Assumptions (Waste):

Waste is dessicated for odor and pathogen control (again, the paper gives values for 0% moisture content; also, liquid waste is separately defined)
Waste is kept in storage but not climate-controlled storage, so it's cooler (astronauts don't need to get into this compartment)

Reference:
https://www.jstage.jst.go.jp/article/jsam/71/1/71_1_1_131/_pdf (page 2)

Assumptions (Wastewater):

The hsp is essentially equal to that of water because the impurity content is low enough to be beneath the given resolution. Most typical domestic wastewater is about 99.94 % water and .06 % impurities, and that includes the solid waste component--space wastewater is likely more pure than that because most of the solid waste is either strained out or never enters the stream in the first place.  Admittedly, astronauts use less water in space, too (no baths, no flush toilets!), but the practical need to reclaim what water they do use means keeping it as pure as possible in order to offset frequency of maintenance for the purifier.  In any case, to show it in terms of hsp would require at least five-place accuracy, and the hsp values given are four-place.

Reference:

Manual of Instruction for Sewage Treatment Plant Operators, NY State Department of Health (page 3)
